### PR TITLE
fix: Hive Watch ログ表示でmessage_typeとevent_type両スキーマ対応

### DIFF
--- a/scripts/hive_watch.py
+++ b/scripts/hive_watch.py
@@ -315,13 +315,19 @@ class HiveWatch:
                     source = log_entry["source"]
                     target = log_entry["target"]
                     message = log_entry["message"]
-                    msg_type = log_entry["message_type"]
+
+                    # message_type と event_type の両方に対応
+                    msg_type = log_entry.get("message_type") or log_entry.get(
+                        "event_type", "unknown"
+                    )
 
                     arrow = (
                         "→"
-                        if msg_type == "task"
+                        if msg_type in ["task", "direct", "task_start"]
                         else "←"
-                        if msg_type == "result"
+                        if msg_type in ["result", "response", "task_complete"]
+                        else "⚡"
+                        if msg_type in ["parallel_start", "parallel_complete"]
                         else "•"
                     )
                     print(


### PR DESCRIPTION
## 概要

Hive Watchのログ表示機能でKeyError: 'message_type'が発生する問題を修正しました。

## 変更内容

- **スキーマ互換性**: `message_type`と`event_type`の両方のログエントリに対応
- **エラー解決**: KeyError発生によるログ表示停止を防止
- **表示改善**: より詳細な矢印記号による通信タイプ識別

### 技術的改善

- `log_entry.get("message_type") or log_entry.get("event_type", "unknown")`による安全な取得
- `task_start`, `task_complete`, `parallel_start`, `parallel_complete`等の追加メッセージタイプサポート
- 適切な矢印記号（→ ← ⚡ •）による視覚的区別

## テスト

- `python3 scripts/hive_watch.py --log`でエラーなく動作確認済み
- 複数の通信ログスキーマでの表示テスト完了

🤖 Generated with [Claude Code](https://claude.ai/code)