### PR TITLE
feat: start-cozy-hiveにダッシュボードサーバー統合

### DIFF
--- a/scripts/start-cozy-hive.sh
+++ b/scripts/start-cozy-hive.sh
@@ -12,17 +12,23 @@ CONFIG_FILE="$BASE_DIR/config/tmux_config.yaml"
 
 # オプション解析
 ENABLE_WATCH=true
+ENABLE_DASHBOARD=true
 while [[ $# -gt 0 ]]; do
     case $1 in
         --no-watch)
             ENABLE_WATCH=false
             shift
             ;;
+        --no-dashboard)
+            ENABLE_DASHBOARD=false
+            shift
+            ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo "Options:"
-            echo "  --no-watch    Hive Watch監視を無効化"
-            echo "  -h, --help    ヘルプを表示"
+            echo "  --no-watch       Hive Watch監視を無効化"
+            echo "  --no-dashboard   ダッシュボードサーバーを無効化"
+            echo "  -h, --help       ヘルプを表示"
             exit 0
             ;;
         *)
@@ -38,6 +44,11 @@ if [[ "$ENABLE_WATCH" == "true" ]]; then
     echo "⌚ Hive Watch monitoring enabled"
 else
     echo "⌚ Hive Watch monitoring disabled"
+fi
+if [[ "$ENABLE_DASHBOARD" == "true" ]]; then
+    echo "📊 Dashboard server enabled"
+else
+    echo "📊 Dashboard server disabled"
 fi
 
 # 既存セッションをチェック
@@ -131,12 +142,38 @@ done
 echo "⏳ Waiting for role templates to load..."
 sleep 5
 
+# Dashboard サーバー起動
+DASHBOARD_WINDOW=7
+if [[ "$ENABLE_DASHBOARD" == "true" ]]; then
+    echo "📊 Starting Dashboard servers..."
+    
+    # Dashboard専用ウィンドウ作成
+    tmux new-window -t "$SESSION_NAME:$DASHBOARD_WINDOW" -n "dashboard" -c "$BASE_DIR/web/dashboard"
+    
+    # API Server (上部ペイン)
+    tmux send-keys -t "$SESSION_NAME:dashboard" "echo '📊 Hive Dashboard - TypeScript + Vue.js版'" C-m
+    tmux send-keys -t "$SESSION_NAME:dashboard" "echo '🔧 Starting Python API Server (port 8000)...'" C-m
+    tmux send-keys -t "$SESSION_NAME:dashboard" "uvicorn api.dashboard_api:app --reload --port 8000" C-m
+    
+    # ペインを分割してVue.js開発サーバー（下部ペイン）
+    tmux split-window -t "$SESSION_NAME:dashboard" -v -c "$BASE_DIR/web/dashboard"
+    tmux send-keys -t "$SESSION_NAME:dashboard" "echo '🌐 Starting Vue.js Dev Server (port 3000)...'" C-m
+    tmux send-keys -t "$SESSION_NAME:dashboard" "sleep 3 && npm run dev" C-m
+    
+    echo "✅ Dashboard servers started on window $DASHBOARD_WINDOW"
+    echo "  - API Server: http://localhost:8000"
+    echo "  - Dashboard: http://localhost:3000"
+    sleep 2
+    
+    DASHBOARD_WINDOW=$((DASHBOARD_WINDOW + 1))
+fi
+
 # Hive Watch監視システム起動
 if [[ "$ENABLE_WATCH" == "true" ]]; then
     echo "⌚ Starting Hive Watch monitoring system..."
     
     # Hive Watch専用ウィンドウ作成
-    tmux new-window -t "$SESSION_NAME:7" -n "hive-watch" -c "$BASE_DIR"
+    tmux new-window -t "$SESSION_NAME:$DASHBOARD_WINDOW" -n "hive-watch" -c "$BASE_DIR"
     
     # Hive Watch初期化
     tmux send-keys -t "$SESSION_NAME:hive-watch" "echo '⌚ Hive Watch - リアルタイム監視システム'" C-m
@@ -149,7 +186,7 @@ if [[ "$ENABLE_WATCH" == "true" ]]; then
     # Python監視システム起動
     tmux send-keys -t "$SESSION_NAME:hive-watch" "python3 scripts/hive_watch.py --monitor --interval 2.0" C-m
     
-    echo "✅ Hive Watch started on window 7 (hive_cli integrated monitoring)"
+    echo "✅ Hive Watch started on window $DASHBOARD_WINDOW (hive_cli integrated monitoring)"
     sleep 2
 fi
 
@@ -166,8 +203,13 @@ echo "  - tester     (window 3) - Testing and quality assurance"
 echo "  - analyzer   (window 4) - Analysis and investigation"
 echo "  - documenter (window 5) - Documentation creation"
 echo "  - reviewer   (window 6) - Code review and validation"
+window_num=7
+if [[ "$ENABLE_DASHBOARD" == "true" ]]; then
+    echo "  - dashboard  (window $window_num) - TypeScript Dashboard (API + Vue.js) 📊"
+    window_num=$((window_num + 1))
+fi
 if [[ "$ENABLE_WATCH" == "true" ]]; then
-    echo "  - hive-watch (window 7) - Real-time monitoring system ⌚"
+    echo "  - hive-watch (window $window_num) - Real-time monitoring system ⌚"
 fi
 echo ""
 echo "🔗 To attach to the cozy session:"
@@ -181,8 +223,13 @@ echo "  Ctrl+b + 3  (Tester)"
 echo "  Ctrl+b + 4  (Analyzer)"
 echo "  Ctrl+b + 5  (Documenter)"
 echo "  Ctrl+b + 6  (Reviewer)"
+window_num=7
+if [[ "$ENABLE_DASHBOARD" == "true" ]]; then
+    echo "  Ctrl+b + $window_num  (Dashboard) 📊"
+    window_num=$((window_num + 1))
+fi
 if [[ "$ENABLE_WATCH" == "true" ]]; then
-    echo "  Ctrl+b + 7  (Hive Watch) ⌚"
+    echo "  Ctrl+b + $window_num  (Hive Watch) ⌚"
 fi
 echo ""
 echo "🔄 Hive CLI Commands (Worker Communication):"
@@ -190,6 +237,13 @@ echo "  - Send message: python3 scripts/hive_cli.py send [worker] '[message]'"
 echo "  - Check status: python3 scripts/hive_cli.py status"
 echo "  - View history: python3 scripts/hive_cli.py history [worker]"
 echo ""
+if [[ "$ENABLE_DASHBOARD" == "true" ]]; then
+    echo "📊 Dashboard URLs:"
+    echo "  - TypeScript Dashboard: http://localhost:3000"
+    echo "  - API Documentation: http://localhost:8000/docs"
+    echo "  - Demo Page: http://localhost:3000/demo.html"
+    echo ""
+fi
 if [[ "$ENABLE_WATCH" == "true" ]]; then
     echo "⌚ Hive Watch Commands (Monitoring):"
     echo "  - View logs: python3 scripts/hive_watch.py --log"
@@ -199,7 +253,15 @@ fi
 echo "🛑 To stop the cozy system:"
 echo "  ./scripts/stop-cozy-hive.sh"
 echo ""
-echo "💡 Pro tip: Use 'Ctrl+b + 7' to quickly check Hive Watch monitoring!"
+dashboard_shortcut=7
+if [[ "$ENABLE_DASHBOARD" == "true" ]]; then
+    echo "💡 Pro tips:"
+    echo "  - Use 'Ctrl+b + $dashboard_shortcut' to check Dashboard servers 📊"
+    dashboard_shortcut=$((dashboard_shortcut + 1))
+fi
+if [[ "$ENABLE_WATCH" == "true" ]]; then
+    echo "  - Use 'Ctrl+b + $dashboard_shortcut' to check Hive Watch monitoring ⌚"
+fi
 
 # セッションにアタッチ
 tmux attach-session -t "$SESSION_NAME"


### PR DESCRIPTION
## 概要

TypeScript + Vue.jsダッシュボード（PR #140）をCozy Hiveシステムに統合し、`start-cozy-hive.sh`実行時に自動起動するようにしました。

## 変更内容

### 🚀 ダッシュボードサーバー自動起動
- **Window 7**: Dashboard専用ウィンドウ
- **分割ペイン構成**: 
  - 上部: Python API Server (uvicorn, port 8000)
  - 下部: Vue.js Dev Server (npm run dev, port 3000)
- **起動順序制御**: API起動 → 3秒待機 → Vue.js起動

### ⚙️ 設定オプション追加
- **`--no-dashboard`**: ダッシュボードサーバーを無効化
- **既存オプション**: `--no-watch` (Hive Watch無効化)
- **組み合わせ可能**: 両方のオプションを同時使用可能

### 🖥️ tmuxレイアウト最適化
- **動的ウィンドウ番号**: Dashboard有効/無効に応じて自動調整
- **Window 7**: Dashboard (Dashboard有効時)
- **Window 8**: Hive Watch (Watch有効時、Dashboard有効)
- **Window 7**: Hive Watch (Watch有効時、Dashboard無効)

### 🌐 アクセス情報表示
起動完了時に以下の情報を表示:
```
📊 Dashboard URLs:
  - TypeScript Dashboard: http://localhost:3000
  - API Documentation: http://localhost:8000/docs
  - Demo Page: http://localhost:3000/demo.html
```

### ⌨️ ショートカット追加
- **Ctrl+b + 7**: Dashboard確認 📊
- **Ctrl+b + 8**: Hive Watch確認 ⌚ (Dashboard有効時)
- **Ctrl+b + 7**: Hive Watch確認 ⌚ (Dashboard無効時)

## 使用方法

### 標準起動（推奨）
```bash
./scripts/start-cozy-hive.sh
# → Dashboard + Watch 両方有効
```

### 選択的起動
```bash
# Dashboard無効
./scripts/start-cozy-hive.sh --no-dashboard

# Watch無効
./scripts/start-cozy-hive.sh --no-watch

# 両方無効（最小構成）
./scripts/start-cozy-hive.sh --no-dashboard --no-watch
```

## テスト

### 品質チェック通過
```bash
make quality  # ✅ All checks passed\!
```

### 起動テスト確認項目
- [ ] Dashboard有効時の正常起動
- [ ] API Server (port 8000) アクセス確認
- [ ] Vue.js Dev Server (port 3000) アクセス確認
- [ ] tmuxウィンドウ配置確認
- [ ] `--no-dashboard`オプション動作確認

## 📊 システム構成

```
Cozy Hive System
├── Window 0: BeeKeeper (ユーザーリクエスト処理)
├── Window 1-6: Worker Panes (Queen, Developer, etc.)
├── Window 7: Dashboard (NEW\!)
│   ├── 上部ペイン: Python API (uvicorn)
│   └── 下部ペイン: Vue.js Dev Server
└── Window 8: Hive Watch (監視システム)
```

## 🎯 期待される効果

1. **開発効率向上**: Cozy Hive起動時に即座にダッシュボード利用可能
2. **統合された監視**: Worker活動とダッシュボードの同時監視
3. **簡単なアクセス**: tmuxショートカットで瞬時にダッシュボード確認
4. **柔軟な構成**: 必要に応じてダッシュボード無効化可能

## 🚀 Ready for Integration

この変更により、Issue #136で実装したTypeScriptダッシュボードがCozy Hiveシステムと完全に統合され、開発者が`start-cozy-hive.sh`を実行するだけで全機能にアクセスできるようになります。

Related to #136