### PR TITLE
fix: Issue #139 beekeeperコンソールへのecho方式報告システム実装

### DIFF
--- a/config/worker_config.yaml
+++ b/config/worker_config.yaml
@@ -1,5 +1,12 @@
 session_name: cozy-hive
 workers:
+  beekeeper:
+    tmux_pane: "cozy-hive:beekeeper"
+    claude_command: "echo"  # beekeeperはecho方式（非Claude）
+    timeout: 10
+    description: "User request handling, message display console"
+    delivery_method: "echo"  # 特殊な配信方式を指定
+    
   queen:
     tmux_pane: "cozy-hive:queen"
     claude_command: "claude-code --role=queen"

--- a/config/worker_config.yaml
+++ b/config/worker_config.yaml
@@ -2,46 +2,54 @@ session_name: cozy-hive
 workers:
   beekeeper:
     tmux_pane: "cozy-hive:beekeeper"
-    claude_command: "echo"  # beekeeperはecho方式（非Claude）
+    claude_command: "echo"  # 現在はecho方式（非Claude）
     timeout: 10
     description: "User request handling, message display console"
-    delivery_method: "echo"  # 特殊な配信方式を指定
+    delivery_method: "echo"  # echo: コンソール表示 | claude_interactive: Claude Code対話型
+    # 注意: delivery_methodを"claude_interactive"に変更し、claude_commandを
+    # "claude --dangerously-skip-permissions"に変更すればClaude Codeワーカーに転換可能
     
   queen:
     tmux_pane: "cozy-hive:queen"
     claude_command: "claude-code --role=queen"
     timeout: 300
     description: "Project management, coordination, strategic decisions"
+    delivery_method: "claude_interactive"  # Claude Code対話型（デフォルト）
     
   developer:
     tmux_pane: "cozy-hive:developer"
     claude_command: "claude-code --role=developer"
     timeout: 300
     description: "Development tasks, code implementation, bug fixes"
+    delivery_method: "claude_interactive"  # Claude Code対話型（デフォルト）
     
   tester:
     tmux_pane: "cozy-hive:tester"
     claude_command: "claude-code --role=tester"
     timeout: 180
     description: "Testing, quality assurance, test case generation"
+    delivery_method: "claude_interactive"  # Claude Code対話型（デフォルト）
     
   analyzer:
     tmux_pane: "cozy-hive:analyzer"
     claude_command: "claude-code --role=analyzer"
     timeout: 240
     description: "Code analysis, investigation, root cause analysis"
+    delivery_method: "claude_interactive"  # Claude Code対話型（デフォルト）
     
   documenter:
     tmux_pane: "cozy-hive:documenter"
     claude_command: "claude-code --role=documenter"
     timeout: 120
     description: "Documentation creation, explanation, user guides"
+    delivery_method: "claude_interactive"  # Claude Code対話型（デフォルト）
     
   reviewer:
     tmux_pane: "cozy-hive:reviewer"
     claude_command: "claude-code --role=reviewer"
     timeout: 180
     description: "Code review, quality validation, security checks"
+    delivery_method: "claude_interactive"  # Claude Code対話型（デフォルト）
 
 # Communication settings
 communication:


### PR DESCRIPTION
## 概要

Issue #139で報告された問題「beekeeperはClaude Codeではない」を解決し、beekeeperへの報告が`echo`コマンドで送信されるよう修正しました。

## 問題の詳細

従来、beekeeperは単純なコンソールとして動作するにも関わらず、他のworkerと同じClaude Code方式での通信が試行されており、適切に報告メッセージが届かない状況でした。

## 解決策

### 🔧 送信方式の分岐実装

**beekeeperとworkerで異なる送信方式を使用**:
- **beekeeper**: echo方式（コンソール表示）
- **worker**: Claude Code方式（対話型通信）

### 📝 実装内容

#### 1. `hive_cli.py`修正
```python
async def _send_direct_message(self, worker: str, message: str, task_id: str):
    if worker == "beekeeper":
        # beekeeperは単純なecho方式
        return await self._send_to_beekeeper(pane_name, message, task_id, start_time)
    else:
        # 他のworkerはClaude Code方式
        return await self._send_to_claude_worker(pane_name, worker, message, task_id, start_time)
```

#### 2. beekeeperへのecho方式送信
```python
async def _send_to_beekeeper(self, pane_name: str, message: str, task_id: str, start_time: float):
    timestamp = datetime.now().strftime("%H:%M:%S")
    formatted_message = f"[{timestamp}] 📨 {message}"
    
    subprocess.run([
        "tmux", "send-keys", "-t", pane_name, 
        f"echo '{formatted_message}'", "Enter"
    ], check=True)
```

#### 3. `worker_config.yaml`にbeekeeper追加
```yaml
workers:
  beekeeper:
    tmux_pane: "cozy-hive:beekeeper"
    claude_command: "echo"  # 非Claude
    timeout: 10
    description: "User request handling, message display console"
    delivery_method: "echo"
```

## 動作確認

### テスト実行
```bash
python3 scripts/hive_cli.py send beekeeper "テストメッセージ" --type direct --no-wait
```

### 期待される結果
```
📤 Sending to beekeeper (echo): テストメッセージ...
✅ Message sent successfully
📝 Response: Message displayed on beekeeper console: テストメッセージ
```

### beekeeperコンソールでの表示
```
[09:00:03] 📨 テストメッセージ
```

## 品質チェック

```bash
make quality  # ✅ All checks passed\!
```

## 🎯 期待される効果

1. **明確な役割分離**: beekeeperはコンソール、workerはClaude Code
2. **確実な報告**: echo方式でbeekeeperに確実にメッセージ表示
3. **システム整合性**: 各コンポーネントの役割が明確化
4. **監視機能維持**: Hive Watchによる透過的監視継続

## 🚀 今後の活用

beekeeperへの報告例:
```bash
# タスク完了報告
python3 scripts/hive_cli.py send beekeeper "タスク完了: Issue #123解決"

# ステータス更新
python3 scripts/hive_cli.py send beekeeper "システム状態: 全worker正常動作中"

# エラー報告
python3 scripts/hive_cli.py send beekeeper "警告: worker developer応答なし"
```

Closes #139