### PR TITLE
feat: Worker roleファイルにGitHub Issue作成機能を追加

### DIFF
--- a/.hive/templates/roles/queen_template.md
+++ b/.hive/templates/roles/queen_template.md
@@ -23,6 +23,11 @@
 - 統合テストの実施
 - 最終的な承認プロセス
 
+### Result Provision
+- 検討・分析結果のGitHub Issue作成
+- 実装結果のPull Request作成
+- BeeKeeperへの最終報告とIssue URL提供
+
 ## Communication Style
 
 ### Professional
@@ -53,6 +58,25 @@
 - 品質基準の達成
 - チームの満足度
 - 顧客の満足度
+- GitHub Issue作成率（検討・分析結果）
+- Pull Request作成率（実装結果）
+
+## GitHub Integration Workflow
+
+### Analysis/Design Results → GitHub Issues
+```bash
+python3 scripts/create_github_issue.py --title "[SESSION_ID] [TASK_TITLE]" --summary "[SUMMARY]" --details "[DETAILS]" --actions "[ACTIONS]" --workers "[WORKERS]" --session-id "[SESSION_ID]"
+```
+
+### Implementation Results → Pull Requests
+```bash
+python3 scripts/create_github_pr.py --title "[IMPLEMENTATION] [FEATURE]" --body "[DETAILS]" --session-id "[SESSION_ID]"
+```
+
+### Final Report to BeeKeeper
+```bash
+python3 scripts/hive_cli.py send beekeeper "QUEEN_FINAL_REPORT:[session_id]:[統合結果] | GitHub Issue: [issue_url]"
+```
 
 ## Escalation Criteria
 
@@ -60,3 +84,4 @@
 - リソース不足
 - 期限の大幅な遅れ
 - 品質問題
+- GitHub Issue作成失敗

--- a/scripts/worker_communication.py
+++ b/scripts/worker_communication.py
@@ -343,7 +343,7 @@ class WorkerCommunicator:
 {instruction}
 
 回答が完了したら、以下のコマンドを実行してQueenに結果を送信してください：
-tmux send-keys -t cozy-hive:queen 'WORKER_RESULT:{worker_name}:{task_id}:[あなたの回答をここに]' Enter
+python3 scripts/hive_cli.py send queen 'WORKER_RESULT:{worker_name}:{task_id}:[あなたの回答をここに]'
 
 その後、[TASK_COMPLETED]と出力してください。
 

--- a/templates/roles/analyzer.md
+++ b/templates/roles/analyzer.md
@@ -58,6 +58,13 @@ python3 scripts/hive_cli.py send [target_worker] "[message]"
 python3 scripts/hive_cli.py send queen "ANALYSIS_RESULT:analyzer:[task_id]:[分析結果の詳細]"
 ```
 
+### 重要な分析結果の場合はGitHub Issue作成も推奨
+複雑な分析結果や重要な発見がある場合、以下のヘルパー関数を使用してGitHub Issue作成を提案してください：
+```bash
+# 分析結果をGitHub Issueとして作成する例
+python3 scripts/create_github_issue.py --title "[ANALYSIS] [分析対象] 分析結果" --summary "[分析の概要]" --details "[詳細な分析結果]" --actions "[推奨アクション]" --workers "analyzer" --session-id "[session_id]"
+```
+
 ### Worker間の協力要請
 他のWorkerに協力を要請する場合：
 ```bash

--- a/templates/roles/developer.md
+++ b/templates/roles/developer.md
@@ -36,6 +36,13 @@ python3 scripts/hive_cli.py send [target_worker] "[message]"
 python3 scripts/hive_cli.py send queen "WORKER_RESULT:developer:[task_id]:[あなたの実装結果の詳細]"
 ```
 
+### 実装完了時のPull Request作成
+実装が完了した場合、以下のヘルパー関数を使用してPull Request作成を提案してください：
+```bash
+# 実装をPull Requestとして作成する例
+python3 scripts/create_github_pr.py --title "[IMPLEMENTATION] [機能名]" --body "[実装内容の詳細]" --session-id "[session_id]"
+```
+
 ### Worker間の協力要請
 他のWorkerに協力を要請する場合：
 ```bash

--- a/templates/roles/documenter.md
+++ b/templates/roles/documenter.md
@@ -58,6 +58,13 @@ python3 scripts/hive_cli.py send [target_worker] "[message]"
 python3 scripts/hive_cli.py send queen "DOC_RESULT:documenter:[task_id]:[文書化成果物の詳細]"
 ```
 
+### 重要なドキュメントの場合はGitHub Issue作成も推奨
+重要なドキュメントや包括的な説明が必要な場合、以下のヘルパー関数を使用してGitHub Issue作成を提案してください：
+```bash
+# ドキュメントをGitHub Issueとして作成する例
+python3 scripts/create_github_issue.py --title "[DOCS] [ドキュメント対象] ドキュメント作成" --summary "[ドキュメントの概要]" --details "[詳細なドキュメント内容]" --actions "[推奨アクション]" --workers "documenter" --session-id "[session_id]"
+```
+
 ### Worker間の協力要請
 他のWorkerに協力を要請する場合：
 ```bash

--- a/templates/roles/queen.md
+++ b/templates/roles/queen.md
@@ -103,11 +103,19 @@ python3 scripts/hive_cli.py list
 python3 scripts/hive_cli.py history [worker_name]
 ```
 
-### BeeKeeperへの最終報告
-全Workerの作業が完了し、結果を統合したら、以下の形式でBeeKeeperに最終報告を送信してください：
+### BeeKeeperへの最終報告とGitHub Issue作成
+全Workerの作業が完了し、結果を統合したら、以下の手順で最終報告を実行してください：
 
+#### 1. GitHub Issue作成
+検討・分析結果は必ずGitHub Issueとして作成してください：
 ```bash
-python3 scripts/hive_cli.py send beekeeper "QUEEN_FINAL_REPORT:[session_id]:[統合された最終結果の要約]"
+python3 scripts/create_github_issue.py --title "[session_id] [タスク概要]" --summary "[要約]" --details "[詳細内容]" --actions "[推奨アクション]" --workers "[使用Worker一覧]" --session-id "[session_id]"
+```
+
+#### 2. BeeKeeperへの最終報告
+GitHub Issue作成後、以下の形式でBeeKeeperに最終報告を送信してください：
+```bash
+python3 scripts/hive_cli.py send beekeeper "QUEEN_FINAL_REPORT:[session_id]:[統合された最終結果の要約] | GitHub Issue: [issue_url]"
 ```
 
 **最終報告の内容に含めるべき項目：**
@@ -119,8 +127,12 @@ python3 scripts/hive_cli.py send beekeeper "QUEEN_FINAL_REPORT:[session_id]:[統
 6. **推奨事項**: 追加で必要な作業があれば提案
 
 **報告例：**
-```
-QUEEN_FINAL_REPORT:session_12345:[
+```bash
+# 1. GitHub Issue作成
+python3 scripts/create_github_issue.py --title "session_12345 Issue #84 分析・説明完了" --summary "Issue #84の根本原因特定とドキュメント作成" --details "analyzer: 根本原因特定（メモリリーク） | documenter: 詳細説明文書作成" --actions "修正コードの実装を検討" --workers "analyzer,documenter" --session-id "session_12345"
+
+# 2. BeeKeeperへの最終報告
+python3 scripts/hive_cli.py send beekeeper "QUEEN_FINAL_REPORT:session_12345:[
 📊 Issue #84 分析・説明完了
 
 🔍 実行Worker: analyzer, documenter
@@ -131,7 +143,7 @@ QUEEN_FINAL_REPORT:session_12345:[
 ✅ 最終結果: Issue #84は...（詳細説明）
 ⭐ 品質評価: 高品質（両Worker正常完了）
 💡 推奨事項: 修正コードの実装を検討
-]
+] | GitHub Issue: https://github.com/nyasuto/hive/issues/162"
 ```
 
 ## 💡 実践的な作業手順
@@ -152,7 +164,12 @@ python3 scripts/hive_cli.py send documenter 'TASK_84_DOC: analyzerの調査結�
 
 4. **結果統合と品質確認**: 受信した結果を統合し、品質を評価
 
-5. **BeeKeeperへの最終報告**:
+5. **GitHub Issue作成**:
+```bash
+python3 scripts/create_github_issue.py --title "session_84 Issue #84 分析・説明完了" --summary "Issue #84の詳細分析と説明文書作成" --details "[analyzer結果] | [documenter結果]" --actions "[推奨アクション]" --workers "analyzer,documenter" --session-id "session_84"
+```
+
+6. **BeeKeeperへの最終報告**:
 ```bash
 python3 scripts/hive_cli.py send beekeeper 'QUEEN_FINAL_REPORT:session_84:[
 📊 Issue #84 分析・説明完了
@@ -165,10 +182,10 @@ python3 scripts/hive_cli.py send beekeeper 'QUEEN_FINAL_REPORT:session_84:[
 ✅ 最終結果: [統合された最終的な説明]
 ⭐ 品質評価: [品質評価]
 💡 推奨事項: [必要に応じて追加提案]
-]'
+] | GitHub Issue: [issue_url]'
 ```
 
-6. **タスク完了**: `[TASK_COMPLETED]` を出力
+7. **タスク完了**: `[TASK_COMPLETED]` を出力
 
 ### 重要な原則
 - **即断即決**: タスク受領後、迷わず適切なWorkerに指示
@@ -176,7 +193,9 @@ python3 scripts/hive_cli.py send beekeeper 'QUEEN_FINAL_REPORT:session_84:[
 - **タスクID**: 重複を避けるため、一意のIDを付与
 - **結果待ち**: Worker完了まで待機し、必ず結果を統合
 - **品質責任**: 最終成果物の品質に責任を持つ
+- **GitHub Issue作成**: **検討・分析結果は必ずGitHub Issueとして作成**
 - **最終報告**: **全Worker完了後、必ずBeeKeeperに最終報告を送信**
+- **Issue URL提供**: **BeeKeeper報告にはGitHub Issue URLを含める**
 - **完了条件**: BeeKeeper報告完了後に `[TASK_COMPLETED]` を出力
 
 ### 緊急時の対応

--- a/templates/roles/reviewer.md
+++ b/templates/roles/reviewer.md
@@ -36,6 +36,13 @@ python3 scripts/hive_cli.py send [target_worker] "[message]"
 python3 scripts/hive_cli.py send queen "REVIEW_RESULT:reviewer:[task_id]:[レビュー評価の詳細]"
 ```
 
+### 重要なレビュー結果の場合はGitHub Issue作成も推奨
+重要な品質問題や改善提案がある場合、以下のヘルパー関数を使用してGitHub Issue作成を提案してください：
+```bash
+# レビュー結果をGitHub Issueとして作成する例
+python3 scripts/create_github_issue.py --title "[REVIEW] [レビュー対象] レビュー結果" --summary "[レビューの概要と評価]" --details "[詳細なレビュー結果と改善提案]" --actions "[推奨改善アクション]" --workers "reviewer" --session-id "[session_id]"
+```
+
 ### Worker間の協力要請
 他のWorkerに協力を要請する場合：
 ```bash

--- a/templates/roles/tester.md
+++ b/templates/roles/tester.md
@@ -161,9 +161,7 @@ hive remind-me     # 現在のタスクと役割を確認
 ### タスク完了時の報告
 タスクが完了したら、以下のコマンドでQueenに結果を送信してください：
 ```bash
-tmux send-keys -t cozy-hive:queen 'WORKER_RESULT:tester:[task_id]:[あなたのテスト結果]' Enter
-sleep 1
-tmux send-keys -t cozy-hive:queen Enter
+python3 scripts/hive_cli.py send queen 'WORKER_RESULT:tester:[task_id]:[あなたのテスト結果]'
 ```
 
 その後、`[TASK_COMPLETED]`と出力してください。

--- a/templates/roles/tester.md
+++ b/templates/roles/tester.md
@@ -86,6 +86,13 @@ python3 scripts/hive_cli.py send [target_worker] "[message]"
 python3 scripts/hive_cli.py send queen "TEST_RESULT:tester:[task_id]:テスト完了。成功率95%、失敗箇所: [詳細]"
 ```
 
+### 重要なテスト結果の場合はGitHub Issue作成も推奨
+重要なバグや品質問題が発見された場合、以下のヘルパー関数を使用してGitHub Issue作成を提案してください：
+```bash
+# テスト結果をGitHub Issueとして作成する例
+python3 scripts/create_github_issue.py --title "[TEST] [テスト対象] テスト結果" --summary "[テストの概要と結果]" --details "[詳細なテスト結果とバグ報告]" --actions "[推奨修正アクション]" --workers "tester" --session-id "[session_id]"
+```
+
 ### 開発チームとの連携
 ```bash
 # Developerにバグ報告


### PR DESCRIPTION
## 概要

Worker roleファイルにGitHub Issue作成機能を追加し、レポートがマークダウンファイルではなくIssueとして作成されるようにしました。

## 主要な変更

### Queen Worker
- **2段階プロセス**: GitHub Issue作成 → BeeKeeper報告
- **Issue URL提供**: 最終報告にGitHub Issue URLを含める
- **必須化**: 検討・分析結果は必ずGitHub Issueとして作成

### 各Worker
- **Analyzer**: 重要な分析結果のGitHub Issue作成推奨
- **Documenter**: 重要なドキュメントのGitHub Issue作成推奨 
- **Tester**: 重要なテスト結果・バグ報告のGitHub Issue作成推奨
- **Reviewer**: 重要なレビュー結果のGitHub Issue作成推奨
- **Developer**: Pull Request作成機能追加

### テンプレート更新
- : GitHub統合ワークフロー追加
- Success Metricsに GitHub Issue/PR作成率を追加

## 効果

- **結果の構造化**: マークダウンファイルではなくGitHub Issueとして管理
- **トレーサビリティ**: Issue URLによる結果の追跡可能
- **統合ワークフロー**: 分析→Issue、実装→PR の明確な流れ
- **品質向上**: 構造化された結果提供による品質向上

## 使用方法

### Queen Worker
```bash
# 1. GitHub Issue作成
python3 scripts/create_github_issue.py --title "session_001 分析結果" --summary "概要" --details "詳細" --actions "アクション" --workers "analyzer,documenter" --session-id "session_001"

# 2. BeeKeeper報告
python3 scripts/hive_cli.py send beekeeper "QUEEN_FINAL_REPORT:session_001:[結果] | GitHub Issue: https://github.com/nyasuto/hive/issues/XXX"
```

### 各Worker
```bash
# 重要な結果のGitHub Issue作成
python3 scripts/create_github_issue.py --title "[ANALYSIS] 重要な分析結果" --summary "概要" --details "詳細" --actions "アクション" --workers "analyzer" --session-id "session_001"
```

これにより、beeたちは自動的にGitHub Issueとして結果を提供するようになります。

🤖 Generated with [Claude Code](https://claude.ai/code)