### PR TITLE
ウィンドウベース表示とキーバインド改善

### DIFF
--- a/bees/config.py
+++ b/bees/config.py
@@ -35,9 +35,9 @@ class BeehiveConfig:
     pane_mapping: dict[str, str] = field(
         default_factory=lambda: {"queen": "queen", "developer": "developer", "qa": "qa"}
     )
-    # ペインIDマッピング（bee名 -> tmuxペインID）
+    # ペインIDマッピング（bee名 -> tmuxウィンドウID）
     pane_id_mapping: dict[str, str] = field(
-        default_factory=lambda: {"queen": "%0", "developer": "%1", "qa": "%2"}
+        default_factory=lambda: {"queen": "beehive:0", "developer": "beehive:1", "qa": "beehive:2"}
     )
 
     # 通信設定
@@ -174,16 +174,19 @@ class BeehiveConfig:
             if bee not in value:
                 raise ValueError(f"Missing pane ID mapping for bee: {bee}")
 
-        # ペインID形式の検証 (%0, %1, %2 or 0.0, 0.1, 0.2 形式)
+        # ウィンドウID形式の検証 (session:N 形式)
         for bee, pane_id in value.items():
             if not isinstance(pane_id, str) or not pane_id:
                 raise ValueError(f"Invalid pane ID for {bee}: {pane_id}")
-            # %N形式または N.N形式をサポート
-            if not (pane_id.startswith("%") and pane_id[1:].isdigit()) and not (
-                pane_id.count(".") == 1 and pane_id.replace(".", "").isdigit()
-            ):
+            # session:N形式をサポート
+            if ":" not in pane_id:
                 raise ValueError(
-                    f"Invalid pane ID format for {bee}: {pane_id} (expected format: %N or N.N)"
+                    f"Invalid window ID format for {bee}: {pane_id} (expected format: session:N)"
+                )
+            session_part, window_part = pane_id.split(":", 1)
+            if not session_part or not window_part.isdigit():
+                raise ValueError(
+                    f"Invalid window ID format for {bee}: {pane_id} (expected format: session:N)"
                 )
 
     @classmethod

--- a/scripts/inject_roles.sh
+++ b/scripts/inject_roles.sh
@@ -85,22 +85,22 @@ inject_all_roles() {
     local success_count=0
     local total_roles=3
     
-    # Inject Queen Bee role (%0)
-    if inject_role_to_pane "%0" "$PROJECT_ROOT/roles/queen.md" "Queen Bee"; then
+    # Inject Queen Bee role (window 0)
+    if inject_role_to_pane "$SESSION_NAME:0" "$PROJECT_ROOT/roles/queen.md" "Queen Bee"; then
         ((success_count++))
     fi
     
     sleep 2
     
-    # Inject Developer Bee role (%1) 
-    if inject_role_to_pane "%1" "$PROJECT_ROOT/roles/developer.md" "Developer Bee"; then
+    # Inject Developer Bee role (window 1) 
+    if inject_role_to_pane "$SESSION_NAME:1" "$PROJECT_ROOT/roles/developer.md" "Developer Bee"; then
         ((success_count++))
     fi
     
     sleep 2
     
-    # Inject QA Bee role (%2)
-    if inject_role_to_pane "%2" "$PROJECT_ROOT/roles/qa.md" "QA Bee"; then
+    # Inject QA Bee role (window 2)
+    if inject_role_to_pane "$SESSION_NAME:2" "$PROJECT_ROOT/roles/qa.md" "QA Bee"; then
         ((success_count++))
     fi
     
@@ -127,13 +127,13 @@ inject_specific_role() {
     
     case "$role_name" in
         "queen"|"0")
-            inject_role_to_pane "%0" "$PROJECT_ROOT/roles/queen.md" "Queen Bee"
+            inject_role_to_pane "$SESSION_NAME:0" "$PROJECT_ROOT/roles/queen.md" "Queen Bee"
             ;;
         "developer"|"dev"|"1")
-            inject_role_to_pane "%1" "$PROJECT_ROOT/roles/developer.md" "Developer Bee"
+            inject_role_to_pane "$SESSION_NAME:1" "$PROJECT_ROOT/roles/developer.md" "Developer Bee"
             ;;
         "qa"|"2")
-            inject_role_to_pane "%2" "$PROJECT_ROOT/roles/qa.md" "QA Bee"
+            inject_role_to_pane "$SESSION_NAME:2" "$PROJECT_ROOT/roles/qa.md" "QA Bee"
             ;;
         *)
             log_error "Unknown role: $role_name"
@@ -150,30 +150,30 @@ verify_roles() {
     # Check if panes are responsive using CLI
     local responsive_panes=0
     
-    for pane_id in "%0" "%1" "%2"; do
-        log_info "Testing pane $pane_id responsiveness..."
+    for window_id in "$SESSION_NAME:0" "$SESSION_NAME:1" "$SESSION_NAME:2"; do
+        log_info "Testing window $window_id responsiveness..."
         
         # Send a simple test question via CLI
-        send_keys_cli "$SESSION_NAME" "$pane_id" "" "heartbeat" "system"
+        send_keys_cli "$SESSION_NAME" "$window_id" "" "heartbeat" "system"
         sleep 0.5
-        send_keys_cli "$SESSION_NAME" "$pane_id" "現在の時刻を教えてください" "verification" "system"
+        send_keys_cli "$SESSION_NAME" "$window_id" "現在の時刻を教えてください" "verification" "system"
         
-        # Check if pane exists and is active using tmux
-        if tmux list-panes -t "$SESSION_NAME:0" | grep -q "$pane_id"; then
+        # Check if window exists and is active using tmux
+        if tmux list-windows -t "$SESSION_NAME" | grep -q "${window_id##*:}:"; then
             ((responsive_panes++))
-            log_info "Pane $pane_id is active"
+            log_info "Window $window_id is active"
         else
-            log_warning "Pane $pane_id may not be active"
+            log_warning "Window $window_id may not be active"
         fi
     done
     
-    log_info "Active panes: $responsive_panes/3"
+    log_info "Active windows: $responsive_panes/3"
     
     if [[ $responsive_panes -eq 3 ]]; then
-        log_success "All panes are responsive - verification via CLI complete"
+        log_success "All windows are responsive - verification via CLI complete"
         return 0
     else
-        log_warning "Some panes may not be responsive"
+        log_warning "Some windows may not be responsive"
         return 1
     fi
 }
@@ -192,9 +192,9 @@ OPTIONS:
     --help, -h          Show this help
 
 ROLES:
-    queen, 0           Inject Queen Bee role (pane 0)
-    developer, dev, 1  Inject Developer Bee role (pane 1)  
-    qa, 2              Inject QA Bee role (pane 2)
+    queen, 0           Inject Queen Bee role (window 0)
+    developer, dev, 1  Inject Developer Bee role (window 1)  
+    qa, 2              Inject QA Bee role (window 2)
 
 EXAMPLES:
     ./scripts/inject_roles.sh                    # Inject all roles via CLI
@@ -212,7 +212,7 @@ FEATURES:
 REQUIREMENTS:
     - Beehive session must be running (./beehive.sh init)
     - Role definition files must exist in roles/ directory
-    - Claude agents must be responsive in each pane
+    - Claude agents must be responsive in each window
     - send-keys CLI must be available (python -m bees.cli)
 
 EOF


### PR DESCRIPTION
## 概要

TMuxの表示を3分割ペインから独立ウィンドウに変更し、操作性を大幅に改善

## 変更内容

### 🖼️ UI/UX改善
- **1 bee = 1 window**: ペイン分割から独立ウィンドウに変更
- **フルスクリーン表示**: 各beeが独立したフルスクリーンで動作
- **絵文字アイコン**: ウィンドウタイトルに識別しやすいアイコン追加

### ⌨️ キーバインド強化
- **直感的ショートカット**: 
  - `Ctrl-b + q` → Queen Bee
  - `Ctrl-b + d` → Developer Bee  
  - `Ctrl-b + a` → QA Bee
- **矢印キー対応**: `Ctrl-b + ←/→` で前後ウィンドウ移動
- **従来操作も維持**: `Ctrl-b + 0/1/2` も継続サポート

### 🔧 技術的改善
- **設定更新**: ペインID形式を`%0`から`beehive:0`に変更
- **自動role injection**: init時に自動実行
- **バリデーション強化**: ウィンドウID形式の検証追加

### 📝 ドキュメント更新
- ヘルプメッセージをウィンドウベースに更新
- 操作方法の説明を追加

## テスト

- 設定バリデーションテスト通過
- コード品質チェック通過 
- tmuxウィンドウ切り替え動作確認

## 使用方法

```bash
# 初期化（自動role injection含む）
./scripts/init_hive.sh

# ウィンドウ切り替え
# Ctrl-b + q (Queen)
# Ctrl-b + d (Developer)  
# Ctrl-b + a (QA)
```

**大幅な操作性向上により、マルチエージェント開発の効率が向上**