### PR TITLE
feat: UUIDベースのタスクID生成システム実装 (#47)

### DIFF
--- a/bees/base_bee.py
+++ b/bees/base_bee.py
@@ -153,7 +153,9 @@ class BaseBee:
             raise DatabaseConnectionError(str(self.hive_db_path), e)
 
     @wrap_database_error
-    def _update_bee_state(self, status: str, task_id: int | None = None, workload: int = 0) -> None:
+    def _update_bee_state(
+        self, status: str, task_id: str | int | None = None, workload: int = 0
+    ) -> None:
         """
         Bee状態をデータベースで更新
 
@@ -217,7 +219,7 @@ class BaseBee:
         message_type: str,
         subject: str,
         content: str,
-        task_id: int | None = None,
+        task_id: str | int | None = None,
         priority: str = "normal",
     ) -> int:
         """他のBeeにメッセージを送信（tmux sender CLI中心）"""
@@ -271,7 +273,7 @@ class BaseBee:
 
         self.logger.info(f"Message {message_id} marked as processed")
 
-    def get_task_details(self, task_id: int) -> dict[str, Any] | None:
+    def get_task_details(self, task_id: str | int) -> dict[str, Any] | None:
         """タスクの詳細情報を取得"""
         with self._get_db_connection() as conn:
             cursor = conn.execute(
@@ -283,7 +285,7 @@ class BaseBee:
             row = cursor.fetchone()
             return dict(row) if row else None
 
-    def update_task_status(self, task_id: int, status: str, notes: str | None = None):
+    def update_task_status(self, task_id: str | int, status: str, notes: str | None = None):
         """タスク状態を更新"""
         with self._get_db_connection() as conn:
             # タスク状態更新
@@ -316,7 +318,7 @@ class BaseBee:
         self.logger.info(f"Task {task_id} status updated to: {status}")
 
     def log_activity(
-        self, task_id: int, activity_type: str, description: str, metadata: dict | None = None
+        self, task_id: str | int, activity_type: str, description: str, metadata: dict | None = None
     ):
         """アクティビティをログに記録"""
         with self._get_db_connection() as conn:
@@ -344,7 +346,7 @@ class BaseBee:
         message_type: str,
         subject: str,
         content: str,
-        task_id: int | None = None,
+        task_id: str | int | None = None,
     ):
         """CLI経由でtmux sender CLIメッセージを送信"""
         if target_bee not in self.pane_id_map:

--- a/bees/queen_bee.py
+++ b/bees/queen_bee.py
@@ -72,7 +72,7 @@ class QueenBee(BaseBee):
         description: str,
         priority: str,
         estimated_hours: float | None,
-        parent_task_id: int | None,
+        parent_task_id: str | int | None,
     ) -> None:
         """タスク入力値を検証
 
@@ -117,7 +117,9 @@ class QueenBee(BaseBee):
                 )
 
         if parent_task_id is not None:
-            if not isinstance(parent_task_id, int) or parent_task_id <= 0:
+            if not isinstance(parent_task_id, int | str) or (
+                isinstance(parent_task_id, int) and parent_task_id <= 0
+            ):
                 raise TaskValidationError(f"Invalid parent_task_id: {parent_task_id}")
 
     @error_handler
@@ -127,7 +129,7 @@ class QueenBee(BaseBee):
         description: str,
         priority: str = "medium",
         estimated_hours: float | None = None,
-        parent_task_id: int | None = None,
+        parent_task_id: str | int | None = None,
     ) -> int:
         """新しいタスクを作成
 
@@ -197,7 +199,7 @@ class QueenBee(BaseBee):
             raise DatabaseConnectionError(f"Failed to create task '{title}': {e}") from e
 
     @error_handler
-    def decompose_task(self, task_id: int, subtasks: list[dict[str, Any]]) -> list[int]:
+    def decompose_task(self, task_id: str | int, subtasks: list[dict[str, Any]]) -> list[int]:
         """タスクをサブタスクに分解
 
         Args:
@@ -212,7 +214,7 @@ class QueenBee(BaseBee):
             WorkflowError: タスク分解処理に失敗した場合
         """
         # 入力値検証
-        if not isinstance(task_id, int) or task_id <= 0:
+        if not isinstance(task_id, int | str) or (isinstance(task_id, int) and task_id <= 0):
             raise TaskValidationError(f"Invalid task_id: {task_id}")
 
         if not subtasks or not isinstance(subtasks, list):
@@ -293,7 +295,7 @@ class QueenBee(BaseBee):
 
     @error_handler
     def assign_task_to_bee(
-        self, task_id: int, target_bee: str, assignment_reason: str = ""
+        self, task_id: str | int, target_bee: str, assignment_reason: str = ""
     ) -> bool:
         """指定されたBeeにタスクを割り当て
 
@@ -311,7 +313,7 @@ class QueenBee(BaseBee):
             WorkflowError: ワークロードが上限を超えている場合
         """
         # 入力値検証
-        if not isinstance(task_id, int) or task_id <= 0:
+        if not isinstance(task_id, int | str) or (isinstance(task_id, int) and task_id <= 0):
             raise TaskValidationError(f"Invalid task_id: {task_id}")
 
         if not target_bee or not isinstance(target_bee, str):
@@ -900,7 +902,7 @@ class QueenBee(BaseBee):
             raise
 
     @error_handler
-    def _handle_task_completion(self, task_id: int, completed_by: str) -> None:
+    def _handle_task_completion(self, task_id: str | int, completed_by: str) -> None:
         """タスク完了時の処理
 
         Args:
@@ -911,7 +913,7 @@ class QueenBee(BaseBee):
             TaskValidationError: タスクIDが無効な場合
             BeeNotFoundError: 完了者が無効な場合
         """
-        if not isinstance(task_id, int) or task_id <= 0:
+        if not isinstance(task_id, int | str) or (isinstance(task_id, int) and task_id <= 0):
             raise TaskValidationError(f"Invalid task_id: {task_id}")
 
         if not completed_by or completed_by not in self.available_bees:
@@ -971,7 +973,7 @@ class QueenBee(BaseBee):
             raise
 
     @error_handler
-    def _get_parent_task(self, task_id: int) -> dict[str, Any] | None:
+    def _get_parent_task(self, task_id: str | int) -> dict[str, Any] | None:
         """親タスクを取得
 
         Args:
@@ -984,7 +986,7 @@ class QueenBee(BaseBee):
             TaskValidationError: タスクIDが無効な場合
             DatabaseConnectionError: データベースアクセスに失敗した場合
         """
-        if not isinstance(task_id, int) or task_id <= 0:
+        if not isinstance(task_id, int | str) or (isinstance(task_id, int) and task_id <= 0):
             raise TaskValidationError(f"Invalid task_id: {task_id}")
 
         try:
@@ -1004,7 +1006,7 @@ class QueenBee(BaseBee):
             raise DatabaseConnectionError(f"Failed to get parent task for {task_id}: {e}") from e
 
     @error_handler
-    def _all_subtasks_completed(self, parent_task_id: int) -> bool:
+    def _all_subtasks_completed(self, parent_task_id: str | int) -> bool:
         """すべてのサブタスクが完了しているかチェック
 
         Args:
@@ -1017,7 +1019,9 @@ class QueenBee(BaseBee):
             TaskValidationError: 親タスクIDが無効な場合
             DatabaseConnectionError: データベースアクセスに失敗した場合
         """
-        if not isinstance(parent_task_id, int) or parent_task_id <= 0:
+        if not isinstance(parent_task_id, int | str) or (
+            isinstance(parent_task_id, int) and parent_task_id <= 0
+        ):
             raise TaskValidationError(f"Invalid parent_task_id: {parent_task_id}")
 
         try:


### PR DESCRIPTION
## 概要
Issue #47で特定された複雑な増分ID生成システムの問題を解決するため、UUIDベースのタスクID生成システムを実装しました。

## 問題
- 複雑なID抽出処理（RETURNING構文への依存）
- SQLiteの制約による実装の複雑化
- パースエラーのリスク
- 並行性の問題
- task_manager.shの複雑な実装

## 解決策
### データベーススキーマ変更
- `task_id`列を`INTEGER PRIMARY KEY AUTOINCREMENT`から`TEXT PRIMARY KEY`に変更
- 全ての外部キー参照を適切に更新

### タスク作成プロセス簡素化
- `uuidgen`コマンドまたはPython `uuid.uuid4()`でUUID生成
- RETURNING構文を削除し、生成されたUUIDを直接使用
- 複雑なID抽出処理を完全に排除

### Python Bee classes更新
- 全ての`task_id`パラメータの型ヒントを`str | int`に更新
- 後方互換性を確保（既存の整数IDも処理可能）
- モダンなPython型構文（`X | Y`）を使用

## 利点
✅ **実装の簡素化**: 複雑なID抽出処理が不要  
✅ **並行性の向上**: UUID衝突リスクが極めて低い  
✅ **即座に利用可能**: 生成されたIDをすぐに使用可能  
✅ **SQLite制約の解決**: RETURNING構文の制約から解放  
✅ **後方互換性**: 既存の整数ベースタスクIDもサポート  

## テスト計画
- [ ] 新規タスク作成のテスト
- [ ] UUID形式の検証
- [ ] 既存整数IDとの互換性テスト
- [ ] 並行タスク作成のテスト

🤖 Generated with [Claude Code](https://claude.ai/code)